### PR TITLE
add devops pipeline for nuget

### DIFF
--- a/TeaFiles.Net.sln
+++ b/TeaFiles.Net.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeaFiles", "TeaFiles\TeaFiles.csproj", "{1CADE377-2821-480D-A0E7-34F224886AF6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TeaFiles", "TeaFiles\TeaFiles.csproj", "{1CADE377-2821-480D-A0E7-34F224886AF6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeaFiles.Test", "TeaFiles.Test\TeaFiles.Test.csproj", "{DB9B6FE9-849F-491D-A356-0609EC45F441}"
 EndProject
@@ -21,6 +21,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sum", "Examples\Sum\Sum.csp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9462292D-69C9-4DF7-87F0-E821FCE86FDD}"
 	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
 		Coverage.testsettings = Coverage.testsettings
 		Normal.testsettings = Normal.testsettings
 		normal32.testsettings = normal32.testsettings

--- a/TeaFiles/TeaFiles.csproj
+++ b/TeaFiles/TeaFiles.csproj
@@ -1,18 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <ProjectGuid>c85b6ff7-387d-48fa-9377-e2c9dd76feb6</ProjectGuid>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>TeaFiles.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <Company>DiscreteLogics</Company>
     <PackageId>TeaFiles.Net</PackageId>
-    <Version>2.0.0</Version>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <Copyright>DiscreteLogics and github contributors</Copyright>
     <Description>Time Series storage in flat files</Description>
     <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Daffy Duck</Authors>
+    <PackageTags>netstandard;netcore;TeaFiles</PackageTags>
+    <PackageProjectUrl>https://github.com/discretelogics/TeaFiles.Net-time-series-storage-in-flat-files</PackageProjectUrl>
+    <PackageReleaseNotes>NONE</PackageReleaseNotes>
+    <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/discretelogics/TeaFiles.Net-time-series-storage-in-flat-files</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,84 @@
+# BASED ON THIS DECENT DESCRIPTION
+# https://ronaldbosma.github.io/blog/2019/09/03/using-multi-stage-yaml-pipeline-to-create-and-publish-nuget-packages/
+
+trigger:
+- master
+
+stages:
+
+- stage: 'Build'
+  variables:
+    buildConfiguration: 'Release'
+
+  jobs:
+  - job:
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    workspace:
+      clean: all
+
+    steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        packageType: sdk
+        version: 2.2.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: DotNetCoreCLI@2
+      displayName: "NuGet Restore"
+      inputs:
+        command: restore
+        projects: '**/TeaFiles.csproj'
+
+    - task: DotNetCoreCLI@2
+      displayName: "Build Solution"
+      inputs:
+        command: build
+        projects: '**/TeaFiles.csproj'
+        arguments: '--configuration $(buildConfiguration)'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'Create NuGet Package - Release Version'
+      inputs:
+        command: pack
+        packagesToPack: '**/TeaFiles.csproj'
+        packDirectory: '$(Build.ArtifactStagingDirectory)/packages/releases'
+        arguments: '--configuration $(buildConfiguration)'
+        nobuild: true
+
+    - task: DotNetCoreCLI@2
+      displayName: 'Create NuGet Package - Prerelease Version'
+      inputs:
+        command: pack
+        packagesToPack: '**/TeaFiles.csproj'
+        buildProperties: 'VersionSuffix="$(Build.BuildNumber)"'
+        packDirectory: '$(Build.ArtifactStagingDirectory)/packages/prereleases'
+        arguments: '--configuration $(buildConfiguration)'
+
+    - publish: '$(Build.ArtifactStagingDirectory)/packages'
+      artifact: 'packages'
+      
+- stage: 'PublishPrereleaseNuGetPackage'
+  displayName: 'Publish Prerelease NuGet Package'
+  dependsOn: 'Build'
+  condition: succeeded()
+  jobs:
+  - job:
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+    - checkout: none
+
+    - download: current
+      artifact: 'packages'
+
+    - task: NuGetCommand@2
+      displayName: 'Push NuGet Package'
+      inputs:
+        command: 'push'
+        packagesToPush: '$(Pipeline.Workspace)/packages/prereleases/*.nupkg'
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'Discretely'      


### PR DESCRIPTION
I use Azure devops for builds.  Since I'd like to move forward with using your library in netstandard2, I made some mods to be able to build and deploy a nuget package to an azure devops nuget repo. It's nothing special as there is no code signing or any of that fancy stuff :)

This PR is submitted in case you might also use azure devops and would find as useful the csproj changes and corresponding yml file.

Here's [the repo](https://pkgs.dev.azure.com/Discretely/_packaging/Discretely/nuget/v3/index.json) in case you want to try it out.